### PR TITLE
Updated README: real .git URL for clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Poor man's function as a service.
 make you have [glide](https://github.com/Masterminds/glide#install) installed first.
 
 ```
-$ git clone github.com/metrue/fx
+$ git clone https://github.com/metrue/fx.git
 $ make install-deps && make build
 ```
 


### PR DESCRIPTION
The URL used to clone is https://github.com/metrue/fx.git and not github.com/metrue/fx.git