### PR TITLE
Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 dist/
 build/
 *.pyc
+fx

--- a/commands/list/list.go
+++ b/commands/list/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/metrue/fx/commands/common"
 )
 
+// List lists all running function services
 func List() {
 	option := "list"
 	nArgs := len(os.Args)

--- a/commands/up/logger.go
+++ b/commands/up/logger.go
@@ -5,21 +5,25 @@ import (
 	"os"
 )
 
-// Customer logger
+// Logger is a customer wrapped logger
 type Logger struct {
 	base *log.Logger
+	log.Logger
 }
 
+// Log outputs an object to stdout
 func (l *Logger) Log(v interface{}) {
 	l.base.SetOutput(os.Stdout)
 	l.base.Print(v)
 }
 
+// Err outputs an object to stderr
 func (l *Logger) Err(v interface{}) {
 	l.base.SetOutput(os.Stderr)
 	l.base.Print(v)
 }
 
+// NewLogger creates a new wrapped log.Logger with default values
 func NewLogger(prefix string) *Logger {
 	return &Logger{
 		base: log.New(

--- a/commands/up/up.go
+++ b/commands/up/up.go
@@ -18,6 +18,7 @@ var langs = map[string]string{
 	".php": "php",
 }
 
+// Up starts the functions specified in flags
 func Up() {
 	option := "up"
 	nArgs := len(os.Args)

--- a/commands/up/worker.go
+++ b/commands/up/worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// Worker handles a functional service
 type Worker struct {
 	conn   *websocket.Conn
 	ch     chan<- bool
@@ -18,14 +19,9 @@ type Worker struct {
 	dead   bool
 }
 
-func NewWorker(
-	src string,
-	lang string,
-	conn *websocket.Conn,
-	ch chan<- bool,
-) *Worker {
+// NewWorker creates and returns a new worker
+func NewWorker(src, lang string, conn *websocket.Conn, ch chan<- bool) *Worker {
 	worker := &Worker{
-		dead:   false,
 		src:    src,
 		lang:   lang,
 		conn:   conn,
@@ -62,25 +58,21 @@ func (worker *Worker) closeHandler(
 	return nil
 }
 
+// Work starts and handles a function from Worker's information
 func (worker *Worker) Work() {
-	logger := worker.logger
-	conn := worker.conn
-	logger.Log("Deploying...")
-
-	// Open function source file
 	if worker.dead {
 		return
 	}
+	logger := worker.logger
+	conn := worker.conn
+	logger.Log("Deploying...")
+	// Open function source file
 	file, err := os.Open(worker.src)
 	if worker.checkErr(err) {
 		return
 	}
 	defer file.Close()
-
 	// Send source language type
-	if worker.dead {
-		return
-	}
 	err = conn.WriteMessage(
 		websocket.TextMessage,
 		[]byte(worker.lang),
@@ -90,9 +82,6 @@ func (worker *Worker) Work() {
 	}
 
 	// Get websocket connection writer
-	if worker.dead {
-		return
-	}
 	writer, err := conn.NextWriter(
 		websocket.TextMessage,
 	)
@@ -101,9 +90,6 @@ func (worker *Worker) Work() {
 	}
 
 	// Send function source file
-	if worker.dead {
-		return
-	}
 	bytesSent, err := io.Copy(
 		writer,
 		file,

--- a/config/config.go
+++ b/config/config.go
@@ -5,11 +5,13 @@ import (
 	"path"
 )
 
+// Server contains the server configuration information
 var Server = map[string]string{
 	"host": "localhost",
 	"port": "8080",
 }
 
+// Client contains the local and remote paths to fetch cached images
 var Client = map[string]string{
 	"cache_dir":         path.Join(os.Getenv("HOME"), ".fx/"),
 	"remote_images_url": "https://raw.githubusercontent.com/metrue/fx/master/images.zip",

--- a/server/docker-api/api.go
+++ b/server/docker-api/api.go
@@ -21,6 +21,7 @@ type dockerInfo struct {
 	Stream string `json:"stream"`
 }
 
+// Build builds a docker image from the image directory
 func Build(name string, dir string) {
 	cli, err := client.NewEnvClient()
 	if err != nil {
@@ -59,13 +60,13 @@ func Build(name string, dir string) {
 	}
 }
 
+// Deploy spins up a new container
 func Deploy(name string, dir string, port string) {
 	ctx := context.Background()
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
-
 	imageName := name
 	containerConfig := &container.Config{
 		Image: imageName,
@@ -94,6 +95,7 @@ func Deploy(name string, dir string, port string) {
 	fmt.Println(resp.ID)
 }
 
+// Stop interrupts a running container
 func Stop(containerID string) (err error) {
 	cli, err := client.NewEnvClient()
 	if err != nil {

--- a/server/env/env.go
+++ b/server/env/env.go
@@ -4,21 +4,22 @@ import (
 	"fmt"
 	"path"
 
-	Config "github.com/metrue/fx/config"
+	"github.com/metrue/fx/config"
 	"github.com/metrue/fx/utils"
 )
 
+// Init creates the server
 func Init() {
-	exist, err := utils.IsPathExists(path.Join(Config.Client["cache_dir"], "images"))
+	exist, err := utils.IsPathExists(path.Join(config.Client["cache_dir"], "images"))
 	if err != nil {
 		panic(err)
 	}
 	if !exist {
 		fmt.Println("Downloading Resources ...")
-		if err := utils.Download("./images.zip", Config.Client["remote_images_url"]); err != nil {
+		if err := utils.Download("./images.zip", config.Client["remote_images_url"]); err != nil {
 			panic(err)
 		}
-		if err := utils.Unzip("./images.zip", Config.Client["cache_dir"]); err != nil {
+		if err := utils.Unzip("./images.zip", config.Client["cache_dir"]); err != nil {
 			panic(err)
 		}
 	}

--- a/server/handlers/down.go
+++ b/server/handlers/down.go
@@ -7,11 +7,8 @@ import (
 	api "github.com/metrue/fx/server/docker-api"
 )
 
-func Down(
-	containID string,
-	msgChan chan<- string,
-	doneChan chan<- bool,
-) {
+// Down stops the processes designated by a function
+func Down(containID string, msgChan chan<- string, doneChan chan<- bool) {
 	checkErr := func(err error) bool {
 		if err != nil {
 			log.Println(err)

--- a/server/handlers/list.go
+++ b/server/handlers/list.go
@@ -7,16 +7,15 @@ import (
 	"github.com/docker/docker/client"
 )
 
+// List returns the list of running services
 func List() []types.Container {
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
-
 	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
 		panic(err)
 	}
-
 	return containers
 }

--- a/server/handlers/up.go
+++ b/server/handlers/up.go
@@ -15,7 +15,10 @@ import (
 )
 
 func closeConnection(connection *websocket.Conn) {
-	connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "0"))
+	connection.WriteMessage(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, "0"),
+	)
 }
 
 var funcNames = map[string]string{
@@ -56,34 +59,23 @@ func initWorkDirectory(lang string, dir string) {
 	}
 }
 
-func Up(
-	lang []byte,
-	body []byte,
-	connection *websocket.Conn,
-	messageType int,
-) {
-	// go func() {
+// Up spins up a new function
+func Up(lang []byte, body []byte, connection *websocket.Conn, messageType int) {
 	var guid = xid.New().String()
 	var dir = guid
 	var name = guid
-
 	port, err := freeport.GetFreePort()
 	if err != nil {
 		panic(err)
 	}
-
 	initWorkDirectory(string(lang), dir)
 	notify(connection, messageType, "work dir initialized")
 	dispatchFuncion(string(lang), body, dir)
 	notify(connection, messageType, "function dispatched")
-
 	api.Build(name, dir)
-
 	notify(connection, messageType, "function built")
 	api.Deploy(name, dir, strconv.Itoa(port))
 	msg := fmt.Sprintf("function deployed at: %s:%s", utils.GetHostIP().String(), strconv.Itoa(port))
 	notify(connection, messageType, msg)
-
 	closeConnection(connection)
-	// }()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -147,6 +147,7 @@ func closeConn(c *websocket.Conn, msg string) {
 	c.WriteMessage(websocket.CloseMessage, byteMsg)
 }
 
+// Start parses input and launches the fx server in a blocking process
 func Start() {
 	flag.Parse()
 	log.SetFlags(0)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 )
 
+// Download a resource from URL to given path
 func Download(filepath string, url string) (err error) {
 	out, err := os.Create(filepath)
 	if err != nil {
@@ -33,6 +34,7 @@ func Download(filepath string, url string) (err error) {
 	return nil
 }
 
+// Unzip a folder to destination
 func Unzip(source string, target string) (err error) {
 	reader, err := zip.OpenReader(source)
 	if err != nil {
@@ -70,6 +72,7 @@ func Unzip(source string, target string) (err error) {
 	return nil
 }
 
+// CopyFile from src to dst
 func CopyFile(src, dst string) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
@@ -112,7 +115,6 @@ func CopyFile(src, dst string) (err error) {
 // CopyDir recursively copies a directory tree, attempting to preserve permissions.
 // Source directory must exist, destination directory must *not* exist.
 // Symlinks are ignored and skipped.
-
 func CopyDir(src string, dst string) (err error) {
 	src = filepath.Clean(src)
 	dst = filepath.Clean(dst)
@@ -168,6 +170,7 @@ func CopyDir(src string, dst string) (err error) {
 	return
 }
 
+// TarDir builds a tar from directory
 func TarDir(srcDir string, desFileName string) {
 	dir, err := os.Open(srcDir)
 	if err != nil {
@@ -216,6 +219,7 @@ func TarDir(srcDir string, desFileName string) {
 	}
 }
 
+// IsPathExists checks whether a path exists or if failed to check
 func IsPathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {
@@ -233,6 +237,7 @@ func checkerror(err error) {
 	}
 }
 
+// GetCurrentExecPath parses a path from running executable/go file
 func GetCurrentExecPath() (scriptPath string) {
 	scriptPath, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
@@ -247,6 +252,7 @@ func HandleError(err error) {
 	}
 }
 
+// GetHostIP returns the host's IP
 func GetHostIP() (ip net.IP) {
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	HandleError(err)


### PR DESCRIPTION
Documentation added to most go functions, in a `go vet`-friendly way.
Some functions are poorly documented as I didn't see exactly what they did, feel free to complete that.

Also removed useless if worker.dead checks.
Some possible further improvement:
* Are 4 sub-packages necessary in `commands` ? They could maybe get regrouped as one.
* config server and client could be structures initialized from ENV variables with default values
* utils could be descriptive and is not idiomatic in go, it regroups functions to handle the file system and HTTP requests. A more explicit package name should be possible 
