### PR TITLE
Remove build image when executing fx down

### DIFF
--- a/server/docker-api/api.go
+++ b/server/docker-api/api.go
@@ -42,13 +42,14 @@ func Build(name string, dir string) {
 	buildOptions := types.ImageBuildOptions{
 		Dockerfile: "Dockerfile", // optional, is the default
 		Tags:       []string{name},
-		Labels:     map[string]string{"fx": ""},
+		Labels:     map[string]string{"belong-to": "fx"},
 	}
 	buildResponse, buildErr := cli.ImageBuild(context.Background(), dockerBuildContext, buildOptions)
 	if buildErr != nil {
 		panic(buildErr)
 	}
 	log.Println("build", buildResponse.OSType)
+	defer buildResponse.Body.Close()
 
 	scanner := bufio.NewScanner(buildResponse.Body)
 	for scanner.Scan() {
@@ -132,4 +133,14 @@ func Remove(containerID string) (err error) {
 		return err
 	}
 	return cli.ContainerRemove(context.Background(), containerID, types.ContainerRemoveOptions{Force: true})
+}
+
+// Remove remove docker image by imageID
+func ImageRemove(imageID string) (err error) {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+	_, err = cli.ImageRemove(context.Background(), imageID, types.ImageRemoveOptions{Force: true})
+	return err
 }

--- a/server/handlers/down.go
+++ b/server/handlers/down.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Down stops the processes designated by a function
-func Down(containID string, msgChan chan<- string, doneChan chan<- bool) {
+func Down(containID, image string, msgChan chan<- string, doneChan chan<- bool) {
 	checkErr := func(err error) bool {
 		if err != nil {
 			log.Println(err)
@@ -24,6 +24,13 @@ func Down(containID string, msgChan chan<- string, doneChan chan<- bool) {
 	}
 
 	fmt.Println("I am closed " + containID)
-	msgChan <- containID + " Stopped"
+	msgChan <- fmt.Sprintf("Container[%s] Removed", containID)
+	if err := api.ImageRemove(image); err != nil {
+		log.Printf("cleanup docker image[%s] error: %s\n", image, err.Error())
+		msgChan <- fmt.Sprintf("Image[%s] Removing Failed", image)
+	} else {
+		msgChan <- fmt.Sprintf("Image[%s] Removed", image)
+	}
+
 	doneChan <- true
 }

--- a/server/handlers/list.go
+++ b/server/handlers/list.go
@@ -9,13 +9,16 @@ import (
 )
 
 // List returns the list of running services
-func List() []types.Container {
+func List(containerIds ...string) []types.Container {
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
 	filters := filters.NewArgs()
-	filters.Add("label", "fx")
+	filters.Add("label", "belong-to=fx")
+	for _, id := range containerIds {
+		filters.Add("id", id)
+	}
 	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{
 		All:     true,
 		Filters: filters,

--- a/server/handlers/up.go
+++ b/server/handlers/up.go
@@ -62,12 +62,13 @@ func initWorkDirectory(lang string, dir string) {
 }
 
 func cleanup(dir string) {
+	format := "cleanup temp file [%s] error: %s\n"
 	if err := os.RemoveAll(dir); err != nil {
-		log.Printf("cleanup [%s] error: %s\n", dir, err.Error())
+		log.Printf(format, dir, err.Error())
 	}
 	dirTar := dir + ".tar"
 	if err := os.RemoveAll(dirTar); err != nil {
-		log.Printf("cleanup [%s] error: %s\n", dirTar, err.Error())
+		log.Printf(format, dirTar, err.Error())
 	}
 }
 


### PR DESCRIPTION
1. Go on working at #69 , the not only container should be removed, images also. 
2. Go on working at #71 , changed the label from `fx=''` to `belong-to='fx'`, looks more readable.
3. Fixed a bug where build image completed should closed response body.