### PR TITLE
review install-deps and gen.sh to use local refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ build/
 *.pyc
 *.swp
 /fx
-tmp/
+/tmp
 /api/google

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ install-deps:
 	go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
 	go get -u github.com/jteeuwen/go-bindata/...
 
-	git clone --depth 1 https://github.com/googleapis/googleapis.git vendor/github.com/googleapis
-	cp -rf vendor/github.com/googleapis/google/ api/google/
+	mkdir -p ./tmp
+	git clone --depth 1 https://github.com/googleapis/googleapis.git tmp/googleapis
 
 	# install protoc
 	./bin/install_protoc.sh

--- a/bin/install_protoc.sh
+++ b/bin/install_protoc.sh
@@ -3,7 +3,7 @@
 HERE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT=$( cd ${HERE}/.. && pwd )
 
-dest_dir="${ROOT}/vendor/protoc"
+dest_dir="${ROOT}/tmp/protoc"
 
 has() {
   type "$1" > /dev/null 2>&1
@@ -27,6 +27,6 @@ else
         url="https://github.com/google/protobuf/releases/download/v3.5.0/protoc-3.5.0-linux-x86_64.zip"
         install_protoc ${url}
     else
-        echo 'Sorry, this script on works on Linux/Mac now'
+        echo 'Sorry, this script works on Linux/Mac now. Please, Create a PR to provide Windows support!'
     fi
 fi


### PR DESCRIPTION
Refer to #110 

- Uses local refs
- Uses tmp instead of vendor (running `dep ensure` seems to remove non dependecy related files)