### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -288,7 +288,7 @@ func GetHostIP() (ip net.IP) {
 	return localAddr.IP
 }
 
-// get programming language from file name extension
+// GetLangFromFileName gets programming language from file name extension
 func GetLangFromFileName(fileName string) (lang string) {
 	extLangMap := map[string]string{
 		".js":   "node",


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?