### PR TITLE
exclude markdown file extraction from install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ download_and_install() {
     local url=$1
     # TODO we can do it on one line
     rm -rf fx.tar.gz
-    curl -o fx.tar.gz -L -O ${url} && tar -xvzf ./fx.tar.gz -C /usr/local/bin
+    curl -o fx.tar.gz -L -O ${url} && tar -xvzf ./fx.tar.gz --exclude=*.md -C /usr/local/bin
     rm -rf ./fx.tar.gz
 }
 


### PR DESCRIPTION
Issue: #282 
Summary: This commit adds the option --exclude=*.md to the install script tar command to avoid extracting any Markdown files to /usr/local/bin

The checklist before PR is ready for review:

- [ ] has unit testing for new added codes
- [ ] has functional testing for new added features
- [ ] has checked the lint or style issues
- [ ] README updated if need
