### PR TITLE
Deployment selector should be immutable

### DIFF
--- a/container_runtimes/docker/sdk/docker.go
+++ b/container_runtimes/docker/sdk/docker.go
@@ -69,10 +69,9 @@ func (d *Docker) BuildImage(ctx context.Context, workdir string, name string) er
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if os.Getenv("DEBUG") != "" {
-		defer resp.Body.Close()
-
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err

--- a/deploy/kubernetes/kubernetes.go
+++ b/deploy/kubernetes/kubernetes.go
@@ -2,10 +2,7 @@ package kubernetes
 
 import (
 	"context"
-	"fmt"
-	"os"
 
-	"github.com/google/uuid"
 	runtime "github.com/metrue/fx/container_runtimes/docker/sdk"
 	"github.com/metrue/fx/deploy"
 	"k8s.io/client-go/kubernetes"
@@ -19,12 +16,7 @@ type K8S struct {
 
 // Create a k8s cluster client
 func Create() (*K8S, error) {
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		return nil, fmt.Errorf("KUBECONFIG not given")
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err := clientcmd.BuildConfigFromKubeconfigGetter("", clientcmd.NewDefaultClientConfigLoadingRules().Load)
 	if err != nil {
 		return nil, err
 	}
@@ -43,6 +35,7 @@ func (k *K8S) Deploy(
 	name string,
 	ports []int32,
 ) error {
+	// TODO: should use the one specified in config file
 	namespace := "default"
 
 	dockerClient, err := runtime.CreateClient(ctx)
@@ -61,7 +54,7 @@ func (k *K8S) Deploy(
 	// be created automatically, then incoming traffic to Service will be forward to Pod.
 	// Then we have no need to create Endpoint manually anymore.
 	selector := map[string]string{
-		"app": "fx-app-" + uuid.New().String(),
+		"app": "fx-app-" + name,
 	}
 
 	const replicas = int32(3)

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -33,7 +33,7 @@ func Deploy(cfg config.Configer) HandleFunc {
 			}
 
 			if err != nil {
-				log.Fatalf("deploy function %s (%s) failed: %v", err)
+				log.Fatalf("deploy function %s (%s) failed: %v", name, funcFile, err)
 			}
 			log.Infof("function %s (%s) deployed successfully", name, funcFile)
 		}()


### PR DESCRIPTION
The checklist before PR is ready for review:

- [ ] has unit testing for new added codes
- [ ] has functional testing for new added features
- [x] has checked the lint or style issues
- [ ] README updated if need

Bind the deployment selector to a specified fx app, which should be unique in the whole cluster.

Deployment selector is immutable over the life cycle of a deployment. The current implementation generates a new UUID even when user tries to **update** a deployment, which will be rejected by k8s as:

```bash
fatal deploy function hello (func.go) failed: Deployment.apps "hello" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"fx-app-cf65f89a-cfd1-4a1f-8f8e-ce74fd187488"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```