### PR TITLE
Skip test when no credentials ready

### DIFF
--- a/deploy/kubernetes/kubernetes_test.go
+++ b/deploy/kubernetes/kubernetes_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 )
 
-func TestK8SRunner(t *testing.T) {
+func TestK8SDeployer(t *testing.T) {
 	workdir := "./fixture"
 	name := "hello"
 	ports := []int32{32300}
 	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		t.Skip("skip test since no KUBECONFIG given in environment variable")
+	username := os.Getenv("DOCKER_USERNAME")
+	password := os.Getenv("DOCKER_PASSWORD")
+	if kubeconfig == "" || username == "" || password == "" {
+		t.Skip("skip test since no KUBECONFIG, DOCKER_USERNAME and DOCKER_PASSWORD given in environment variable")
 	}
 	k8s, err := Create()
 	if err != nil {

--- a/scripts/test_cli.sh
+++ b/scripts/test_cli.sh
@@ -16,9 +16,13 @@ run() {
 deploy() {
   local lang=$1
   local port=$2
-  $fx deploy --name ${service}_${lang} --port ${port} test/functions/func.${lang}
-  docker ps
-  $fx destroy ${service}_${lang}
+  if [[ -z "$DOCKER_USERNAME" || -z "$DOCKER_PASSWORD" ]];then
+    echo "skip deploy test since no DOCKER_USERNAME and DOCKER_PASSWORD set"
+  else
+    $fx deploy --name ${service}_${lang} --port ${port} test/functions/func.${lang}
+    docker ps
+    $fx destroy ${service}_${lang}
+  fi
 }
 
 build_image() {


### PR DESCRIPTION
Issue: <url to the issue to fix>
Summary: 
 Since fork PR build could not read secrets of GitHub action,
    https://github.community/t5/GitHub-Actions/Allow-secrets-to-be-shared-with-trusted-Actions/td-p/34278
    so we should skip test when its credentials are nod ready

The checklist before PR is ready for review:

- [ ] has unit testing for new added codes
- [ ] has functional testing for new added features
- [ ] has checked the lint or style issues
- [ ] README updated if need
