### PR TITLE
naming and environment check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,14 @@ jobs:
         run: |
           export KUBECONFIG=${HOME}/.kube/aks
           echo ${AKS_KUBECONFIG} | base64 -d > $KUBECONFIG
-          DEBUG=true ./build/fx deploy -n hello -p 12345 examples/functions/JavaScript/func.js
-          ./build/fx destroy hello
-          rm ${KUBECONFIG}
+          if [[ -z "$DOCKER_USERNAME" || -z "$DOCKER_PASSWORD" || -z "$AKS_KUBECONFIG" ]];then
+            echo "skip deploy test since no DOCKER_USERNAME and DOCKER_PASSWORD set"
+          else
+            DEBUG=true ./build/fx deploy -n hello -p 12345 examples/functions/JavaScript/func.js
+            ./build/fx destroy hello
+            rm ${KUBECONFIG}
+          fi
+
   Installation:
     runs-on: ${{ matrix.os }}
     needs: [Test]

--- a/scripts/test_cli.sh
+++ b/scripts/test_cli.sh
@@ -19,9 +19,9 @@ deploy() {
   if [[ -z "$DOCKER_USERNAME" || -z "$DOCKER_PASSWORD" ]];then
     echo "skip deploy test since no DOCKER_USERNAME and DOCKER_PASSWORD set"
   else
-    $fx deploy --name ${service}_${lang} --port ${port} test/functions/func.${lang}
+    $fx deploy --name ${service}-${lang} --port ${port} test/functions/func.${lang}
     docker ps
-    $fx destroy ${service}_${lang}
+    $fx destroy ${service}-${lang}
   fi
 }
 


### PR DESCRIPTION
Issue: <url to the issue to fix>
Summary: <a brief summary of PR purpose>
 * kuberntes has some limitation on naming,By convention, the names of Kubernetes resources should be up to maximum length of 253 characters and consist of lower case alphanumeric characters, -, and ., but certain resources have more specific restrictions.
 * skip run deploy when KUBECONFIG, DOCKER_USERNAME, and DOCKER_PASSWORD is not ready

The checklist before PR is ready for review:

- [ ] has unit testing for new added codes
- [ ] has functional testing for new added features
- [ ] has checked the lint or style issues
- [ ] README updated if need
