### PR TITLE
Point to instructions to build from source for non-x86 targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Feel free hacking fx to support the languages not listed. Welcome to tweet me [@
 
 # Installation
 
+Binaries are available for Windows, MacOS and Linux/Unix on x86. For other architectures and platforms, follow instructions to [build fx from source](#buildtest).
+
 * MacOS
 
 ```
@@ -229,6 +231,7 @@ fx uses [Project](https://github.com/metrue/fx/projects/4) to manage the develop
 Docker: make sure [Docker](https://docs.docker.com/engine/installation/) installed and running on your server.
 
 
+<a name="buildtest"></a>
 #### Build & Test
 
 ```

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ curl -o- https://raw.githubusercontent.com/metrue/fx/master/scripts/install.sh |
 curl -o- https://raw.githubusercontent.com/metrue/fx/master/scripts/install.sh | sudo bash
 ```
 
-fx will be installed into /usr/local/bin, sometimes you may need `source ~/.zshrc` or `source ~/.bashrc` to make fx available in `$PAHT`.
+fx will be installed into /usr/local/bin, sometimes you may need `source ~/.zshrc` or `source ~/.bashrc` to make fx available in `$PATH`.
 
-* Window
+* Windows
 
 You can go the release page to [download](https://github.com/metrue/fx/releases) fx manually;
 


### PR DESCRIPTION
Summary: Installation instructions do not specify clearly enough the fact that they are supported only on x86.  Make it clearer and point to the `Build and Test` section in `Contribute` for instructions on building `fx`.

The checklist before PR is ready for review:

- [ ] has unit testing for new added codes
- [ ] has functional testing for new added features
- [ ] has checked the lint or style issues
- [ ] README updated if need
