### PR TITLE
use lighter-weight node image

### DIFF
--- a/assets/dockerfiles/base/node/Dockerfile
+++ b/assets/dockerfiles/base/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:alpine
 
 COPY . .
 RUN npm install

--- a/container_runtimes/docker/http/asserts/dockerfiles/base/node/Dockerfile
+++ b/container_runtimes/docker/http/asserts/dockerfiles/base/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:alpine
 
 COPY . .
 RUN npm install


### PR DESCRIPTION
Issue: https://github.com/metrue/fx/issues/517
Summary: replace full (debian-based) node image with lighter (alpine-based) node image

The checklist before PR is ready for review:

- [x] has unit testing for new added codes
- [ ] has functional testing for new added features
- [ ] has checked the lint or style issues (*)
- [ ] README updated if need

(*) `make lint` currently fails for me on unrelated files