### PR TITLE
Fix the wrong arch of target host

### DIFF
--- a/middlewares/driver.go
+++ b/middlewares/driver.go
@@ -1,8 +1,9 @@
 package middlewares
 
 import (
+	"bytes"
 	"fmt"
-	"runtime"
+	"strings"
 	"time"
 
 	"github.com/apex/log"
@@ -12,7 +13,7 @@ import (
 	dockerDriver "github.com/metrue/fx/driver/docker"
 	k8sInfra "github.com/metrue/fx/driver/k8s"
 	"github.com/metrue/fx/provisioner"
-	darwin "github.com/metrue/fx/provisioner/darwin"
+	"github.com/metrue/fx/provisioner/darwin"
 	linux "github.com/metrue/fx/provisioner/linux"
 	"github.com/metrue/go-ssh-client"
 )
@@ -32,17 +33,28 @@ func Driver(ctx context.Contexter) (err error) {
 		if err := driver.Ping(ctx.GetContext()); err != nil {
 			log.Infof("provisioning %s ...", host)
 
-			var provisioner provisioner.Provisioner
-			// TODO actually we should get os of target host, not the host of fx
-			// running on
-			if runtime.GOOS == "darwin" {
-				provisioner = darwin.New(sshClient)
-			} else {
-				provisioner = linux.New(sshClient)
-			}
-			isRemote := (host != "127.0.0.1" && host != "localhost")
-			if err := provisioner.Provision(ctx.GetContext(), isRemote); err != nil {
+			ok, err := sshClient.Connectable(provisioner.SSHConnectionTimeout)
+			if err != nil {
 				return err
+			}
+			if !ok {
+				return fmt.Errorf("target host could not be connected with SSH")
+			}
+
+			var buf bytes.Buffer
+			if err := sshClient.RunCommand("uname -a", ssh.CommandOptions{Stdout: &buf}); err != nil {
+				return err
+			}
+
+			isRemote := (host != "127.0.0.1" && host != "localhost")
+			if strings.Contains(strings.ToLower(buf.String()), "darwin") {
+				if err := darwin.New(sshClient).Provision(ctx.GetContext(), isRemote); err != nil {
+					return err
+				}
+			} else {
+				if err := linux.New(sshClient).Provision(ctx.GetContext(), isRemote); err != nil {
+					return err
+				}
 			}
 			time.Sleep(2 * time.Second)
 		}

--- a/middlewares/driver_test.go
+++ b/middlewares/driver_test.go
@@ -52,7 +52,8 @@ users:
 	defer os.Remove(kubeconf.Name())
 
 	sshClient := sshMocks.NewMockClienter(ctrl)
-	sshClient.EXPECT().Connectable(10*time.Second).Return(true, nil).Times(2)
+	sshClient.EXPECT().Connectable(10*time.Second).Return(true, nil).Times(3)
+	sshClient.EXPECT().RunCommand("uname -a", gomock.Any()).Return(nil)
 	sshClient.EXPECT().RunCommand("docker version", ssh.CommandOptions{
 		Timeout: 10 * time.Second,
 	}).Return(nil)

--- a/middlewares/parse.go
+++ b/middlewares/parse.go
@@ -29,7 +29,6 @@ func set(ctx context.Contexter, cli *cli.Context, fields []argsField) error {
 				ctx.Set("host", ip)
 				ctx.Set("user", user)
 			} else {
-
 				ctx.Set(f.Name, cli.String(f.Name))
 			}
 		} else if f.Type == "int" {

--- a/provisioner/darwin/darwin.go
+++ b/provisioner/darwin/darwin.go
@@ -6,13 +6,10 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/metrue/fx/provisioner"
 	"github.com/metrue/go-ssh-client"
 )
-
-const sshConnectionTimeout = 10 * time.Second
 
 var scripts = map[string]string{
 	"docker_version": "docker version",
@@ -52,7 +49,7 @@ func (d *Docker) Provision(ctx context.Context, isRemote bool) error {
 
 func (d *Docker) runCmd(script string, isRemote bool, options ...ssh.CommandOptions) error {
 	option := ssh.CommandOptions{
-		Timeout: sshConnectionTimeout,
+		Timeout: provisioner.SSHConnectionTimeout,
 	}
 	if len(options) >= 1 {
 		option = options[0]
@@ -72,7 +69,7 @@ func (d *Docker) runCmd(script string, isRemote bool, options ...ssh.CommandOpti
 		}
 		return nil
 	}
-	ok, err := d.sshClient.Connectable(sshConnectionTimeout)
+	ok, err := d.sshClient.Connectable(provisioner.SSHConnectionTimeout)
 	if err != nil {
 		return fmt.Errorf("could not connect via SSH: '%s'", err)
 	}

--- a/provisioner/darwin/darwin_test.go
+++ b/provisioner/darwin/darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/metrue/fx/provisioner"
 	"github.com/metrue/go-ssh-client"
 	sshMocks "github.com/metrue/go-ssh-client/mocks"
 )
@@ -18,7 +19,7 @@ func TestDriverProvision(t *testing.T) {
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := &Docker{sshClient: sshClient}
 		err := errors.New("could not connect to host")
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(false, err).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(false, err).AnyTimes()
 		if err := n.Provision(context.Background(), true); err == nil {
 			t.Fatalf("should get error when SSH connection not ok")
 		}
@@ -30,7 +31,7 @@ func TestDriverProvision(t *testing.T) {
 
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(false, nil).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(false, nil).AnyTimes()
 		if err := n.Provision(context.Background(), true); err == nil {
 			t.Fatalf("should get error when SSH connection not ok")
 		}
@@ -42,9 +43,9 @@ func TestDriverProvision(t *testing.T) {
 
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil).AnyTimes()
-		sshClient.EXPECT().RunCommand(scripts["docker_version"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil).AnyTimes()
+		sshClient.EXPECT().RunCommand(scripts["docker_version"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
 		if err := n.Provision(context.Background(), true); err != nil {
 			t.Fatal(err)
 		}
@@ -56,10 +57,10 @@ func TestDriverProvision(t *testing.T) {
 
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil).AnyTimes()
 		err := errors.New("docker command not found")
-		sshClient.EXPECT().RunCommand(scripts["docker_version"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err)
-		sshClient.EXPECT().RunCommand(scripts["has_docker"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err)
+		sshClient.EXPECT().RunCommand(scripts["docker_version"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err)
+		sshClient.EXPECT().RunCommand(scripts["has_docker"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err)
 		if err := n.Provision(context.Background(), true); err == nil {
 			t.Fatal("should tell user to install docker first")
 		}
@@ -71,11 +72,11 @@ func TestDriverProvision(t *testing.T) {
 
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil).AnyTimes()
 		err := errors.New("fx agent not found")
-		sshClient.EXPECT().RunCommand(scripts["docker_version"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err)
-		sshClient.EXPECT().RunCommand(scripts["start_fx_agent"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["docker_version"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err)
+		sshClient.EXPECT().RunCommand(scripts["start_fx_agent"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
 		if err := n.Provision(context.Background(), true); err != nil {
 			t.Fatal(err)
 		}
@@ -88,9 +89,9 @@ func TestDriverProvision(t *testing.T) {
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
 
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil).AnyTimes()
-		sshClient.EXPECT().RunCommand(scripts["docker_version"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"], ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil).AnyTimes()
+		sshClient.EXPECT().RunCommand(scripts["docker_version"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"], ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
 		if err := n.Provision(context.Background(), true); err != nil {
 			t.Fatal(err)
 		}
@@ -107,9 +108,9 @@ func TestRunCommand(t *testing.T) {
 	}
 	script := "script"
 	option := ssh.CommandOptions{
-		Timeout: sshConnectionTimeout,
+		Timeout: provisioner.SSHConnectionTimeout,
 	}
-	sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil)
+	sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil)
 	sshClient.EXPECT().RunCommand(script, option).Return(nil)
 	if err := n.runCmd(script, true, option); err != nil {
 		t.Fatal(err)

--- a/provisioner/linux/linux.go
+++ b/provisioner/linux/linux.go
@@ -5,13 +5,10 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/metrue/fx/provisioner"
 	"github.com/metrue/go-ssh-client"
 )
-
-const sshConnectionTimeout = 10 * time.Second
 
 var scripts = map[string]interface{}{
 	"docker_version": "docker version",
@@ -58,7 +55,7 @@ func (d *Docker) Provision(ctx context.Context, isRemote bool) error {
 
 func (d *Docker) runCmd(script string, isRemote bool, options ...ssh.CommandOptions) error {
 	option := ssh.CommandOptions{
-		Timeout: sshConnectionTimeout,
+		Timeout: provisioner.SSHConnectionTimeout,
 	}
 	if len(options) >= 1 {
 		option = options[0]
@@ -78,7 +75,7 @@ func (d *Docker) runCmd(script string, isRemote bool, options ...ssh.CommandOpti
 		}
 		return nil
 	}
-	ok, err := d.sshClient.Connectable(sshConnectionTimeout)
+	ok, err := d.sshClient.Connectable(provisioner.SSHConnectionTimeout)
 	if err != nil {
 		return fmt.Errorf("could not connect via SSH: '%s'", err)
 	}

--- a/provisioner/linux/linux_test.go
+++ b/provisioner/linux/linux_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/metrue/fx/provisioner"
 	"github.com/metrue/go-ssh-client"
 	sshMocks "github.com/metrue/go-ssh-client/mocks"
 )
@@ -18,7 +19,7 @@ func TestDriverProvision(t *testing.T) {
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := &Docker{sshClient: sshClient}
 		err := errors.New("could not connect to host")
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(false, err).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(false, err).AnyTimes()
 		if err := n.Provision(context.Background(), true); err == nil {
 			t.Fatalf("should get error when SSH connection not ok")
 		}
@@ -30,7 +31,7 @@ func TestDriverProvision(t *testing.T) {
 
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(false, nil).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(false, nil).AnyTimes()
 		if err := n.Provision(context.Background(), true); err == nil {
 			t.Fatalf("should get error when SSH connection not ok")
 		}
@@ -42,9 +43,9 @@ func TestDriverProvision(t *testing.T) {
 
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil).AnyTimes()
-		sshClient.EXPECT().RunCommand(scripts["docker_version"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil).AnyTimes()
+		sshClient.EXPECT().RunCommand(scripts["docker_version"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
 		if err := n.Provision(context.Background(), true); err != nil {
 			t.Fatal(err)
 		}
@@ -56,13 +57,13 @@ func TestDriverProvision(t *testing.T) {
 
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil).AnyTimes()
 		err := errors.New("docker command not found")
-		sshClient.EXPECT().RunCommand(scripts["docker_version"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err)
-		sshClient.EXPECT().RunCommand(scripts["has_docker"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err)
-		sshClient.EXPECT().RunCommand(scripts["install_docker"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["start_dockerd"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["docker_version"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err)
+		sshClient.EXPECT().RunCommand(scripts["has_docker"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err)
+		sshClient.EXPECT().RunCommand(scripts["install_docker"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["start_dockerd"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
 		if err := n.Provision(context.Background(), true); err != nil {
 			t.Fatal(err)
 		}
@@ -74,11 +75,11 @@ func TestDriverProvision(t *testing.T) {
 
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil).AnyTimes()
 		err := errors.New("fx agent not found")
-		sshClient.EXPECT().RunCommand(scripts["docker_version"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err)
-		sshClient.EXPECT().RunCommand(scripts["start_fx_agent"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["docker_version"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err)
+		sshClient.EXPECT().RunCommand(scripts["start_fx_agent"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
 		if err := n.Provision(context.Background(), true); err != nil {
 			t.Fatal(err)
 		}
@@ -91,15 +92,15 @@ func TestDriverProvision(t *testing.T) {
 		sshClient := sshMocks.NewMockClienter(ctrl)
 		n := New(sshClient)
 
-		sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil).AnyTimes()
+		sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil).AnyTimes()
 		err2 := errors.New("fx agent not found")
 		err1 := errors.New("docker command not found")
-		sshClient.EXPECT().RunCommand(scripts["docker_version"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err1)
-		sshClient.EXPECT().RunCommand(scripts["has_docker"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err1)
-		sshClient.EXPECT().RunCommand(scripts["install_docker"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["start_dockerd"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
-		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(err2)
-		sshClient.EXPECT().RunCommand(scripts["start_fx_agent"].(string), ssh.CommandOptions{Timeout: sshConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["docker_version"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err1)
+		sshClient.EXPECT().RunCommand(scripts["has_docker"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err1)
+		sshClient.EXPECT().RunCommand(scripts["install_docker"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["start_dockerd"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
+		sshClient.EXPECT().RunCommand(scripts["check_fx_agent"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(err2)
+		sshClient.EXPECT().RunCommand(scripts["start_fx_agent"].(string), ssh.CommandOptions{Timeout: provisioner.SSHConnectionTimeout}).Return(nil)
 		if err := n.Provision(context.Background(), true); err != nil {
 			t.Fatal(err)
 		}
@@ -116,9 +117,9 @@ func TestRunCommand(t *testing.T) {
 	}
 	script := "script"
 	option := ssh.CommandOptions{
-		Timeout: sshConnectionTimeout,
+		Timeout: provisioner.SSHConnectionTimeout,
 	}
-	sshClient.EXPECT().Connectable(sshConnectionTimeout).Return(true, nil)
+	sshClient.EXPECT().Connectable(provisioner.SSHConnectionTimeout).Return(true, nil)
 	sshClient.EXPECT().RunCommand(script, option).Return(nil)
 	if err := n.runCmd(script, true, option); err != nil {
 		t.Fatal(err)

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -1,6 +1,12 @@
 package provisioner
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// SSHConnectionTimeout default timeout for ssh connection
+const SSHConnectionTimeout = 10 * time.Second
 
 // Provisioner define provisioner interface
 type Provisioner interface {


### PR DESCRIPTION
Issue: https://github.com/metrue/fx/issues/523
Summary: 
* get the OS arch with `uname -a`
* refactor the SSHConnectionTimeout constant

The checklist before PR is ready for review:

- [ ] has unit testing for new added codes
- [ ] has functional testing for new added features
- [ ] has checked the lint or style issues
- [ ] README updated if need
