### PR TITLE
delete minor unreachable code caused by log.Fatal

### DIFF
--- a/contrib/docker_packer/main.go
+++ b/contrib/docker_packer/main.go
@@ -36,19 +36,16 @@ docker_packer <encrypt_docker_project_source_tree> <image_name>
 	str, err := base64.StdEncoding.WithPadding(base64.StdPadding).DecodeString(meta)
 	if err != nil {
 		log.Fatalf("could decode meta: %s, %v", meta, err)
-		os.Exit(1)
 	}
 
 	var tree map[string]string
 	//nolint
 	if err := json.Unmarshal([]byte(str), &tree); err != nil {
 		log.Fatalf("could not unmarshal meta: %s", meta)
-		os.Exit(1)
 	}
 	workdir := "/tmp/fx"
 	if err := packer.TreeToDir(tree, workdir); err != nil {
 		log.Fatalf("could not restore to dir: %v", err)
-		os.Exit(1)
 	}
 	defer os.RemoveAll(workdir)
 
@@ -56,17 +53,14 @@ docker_packer <encrypt_docker_project_source_tree> <image_name>
 	dockerClient, err := runtime.CreateClient(ctx)
 	if err != nil {
 		log.Fatalf("could not create a docker client: %v", err)
-		os.Exit(1)
 	}
 	if err := dockerClient.BuildImage(ctx, workdir, name); err != nil {
 		log.Fatalf("could not build image: %s", err)
-		os.Exit(1)
 	}
 
 	nameWithTag := name + ":latest"
 	if err := dockerClient.ImageTag(ctx, name, nameWithTag); err != nil {
 		log.Fatalf("could tag image: %v", err)
-		os.Exit(1)
 	}
 	var imgInfo dockerTypes.ImageInspect
 	if err := utils.RunWithRetry(func() error {


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

Issue: <url to the issue to fix>
Summary: https://pkg.go.dev/log#Fatalf
> Fatalf is equivalent to Printf() followed by a call to os.Exit(1).

The checklist before PR is ready for review:

- [ ] has unit testing for new added codes
- [ ] has functional testing for new added features
- [x] has checked the lint or style issues
- [ ] README updated if need


