### PR TITLE
correct `fx up -p` usage in node.js example

### DIFF
--- a/examples/functions/JavaScript/README.md
+++ b/examples/functions/JavaScript/README.md
@@ -11,7 +11,7 @@ module.exports = (ctx) => {
 then deploy it with `fx up` command,
 
 ```shell
-$ fx up -p 8080:3000 func.js
+$ fx up -p 8080 func.js
 ```
 
 test it using `curl`


### PR DESCRIPTION
Issue: no issue
Summary: fixes the command in the node.js example, using `-p 8080` instead of `-p 8080:3000`
