### PR TITLE
fix: wrong port in Rust example

### DIFF
--- a/examples/functions/Rust/README.md
+++ b/examples/functions/Rust/README.md
@@ -33,7 +33,7 @@ $ fx up -p 8080 func.rs
 test it using `curl`
 
 ```shell
-$ curl -X 'POST' --header 'Content-Type: application/json' --data '{"a":1,"b":1}' '0.0.0.0:3000'
+$ curl -X 'POST' --header 'Content-Type: application/json' --data '{"a":1,"b":1}' '0.0.0.0:8080'
 
 HTTP/1.1 200 OK
 Content-Length: 12


### PR DESCRIPTION
If I'm not mistaken the port should be `8080`, not `3000`, based on the `fx up -p 8080 func.rs` command.